### PR TITLE
automatic use join query when expand foreignkey; strip after split

### DIFF
--- a/rest_flex_fields/views.py
+++ b/rest_flex_fields/views.py
@@ -1,55 +1,62 @@
+import string
 from rest_framework import viewsets
 
 
+def safe_split(split_str, separator=','):
+    return map(string.strip, split_str.split(separator))
+
+
 class FlexFieldsMixin(object):
-	""" 
-	    Dynamically generates the serializer_class with dynamic parameters set from incoming GET params.
-	"""
+    """ 
+        Dynamically generates the serializer_class with dynamic parameters set from incoming GET params.
+    """
 
-	permit_list_expands = []
-	_expandable = True
-	_force_expand = []
-	    
-	def list(self, request, *args, **kwargs):
-		""" Examines request and allows certain fields to be expanded within the list view. """
+    permit_list_expands = []
+    _expandable = True
+    _force_expand = []
 
-		self._expandable = False
-		expand = request.query_params.get('expand')
+    def list(self, request, *args, **kwargs):
+        """ Examines request and allows certain fields to be expanded within the list view. """
 
-		if len(self.permit_list_expands) > 0 and expand:
-			if expand == '~all':
-				self._force_expand = self.permit_list_expands
-			else:
-				self._force_expand = list( 
-					set(expand.split(',')) & set(self.permit_list_expands) 
-				)
+        self._expandable = False
+        expand = request.query_params.get('expand')
 
-		return super(FlexFieldsMixin, self).list(request, *args, **kwargs)
-	
-	
-	def get_serializer_class(self):
-		""" Dynamically adds properties to serializer_class from request's GET params. """
+        if len(self.permit_list_expands) > 0 and expand:
+            if expand == '~all':
+                self._force_expand = self.permit_list_expands
+                self.queryset = self.queryset.select_related()
+            else:
+                expandable_list = list(set(safe_split(expand)) & set(self.permit_list_expands))
+                for expandable_obj in expandable_list:
+                    self.queryset = self.queryset.select_related(expandable_obj)
 
-		expand = None
-		fields = None
-		is_valid_request = hasattr(self, 'request') and self.request.method == 'GET'
+                self._force_expand = expandable_list
 
-		if not is_valid_request:
-			return self.serializer_class
+        return super(FlexFieldsMixin, self).list(request, *args, **kwargs)
 
-		fields = self.request.query_params.get('fields')
-		fields = fields.split(',') if fields else None
-		
-		if self._expandable:
-			expand = self.request.query_params.get('expand')
-			expand = expand.split(',') if expand else None
-		elif len(self._force_expand) > 0:
-			expand = self._force_expand
-		
-		return type('DynamicFieldsModelSerializer', (self.serializer_class,), {
-			'expand': expand, 
-			'include_fields': fields,
-		})
+    def get_serializer_class(self):
+        """ Dynamically adds properties to serializer_class from request's GET params. """
+
+        expand = None
+        fields = None
+        is_valid_request = hasattr(self, 'request') and self.request.method == 'GET'
+
+        if not is_valid_request:
+            return self.serializer_class
+
+        fields = self.request.query_params.get('fields')
+        fields = safe_split(fields) if fields else None
+
+        if self._expandable:
+            expand = self.request.query_params.get('expand')
+            expand = safe_split(expand) if expand else None
+        elif len(self._force_expand) > 0:
+            expand = self._force_expand
+
+        return type('DynamicFieldsModelSerializer', (self.serializer_class,), {
+            'expand': expand,
+            'include_fields': fields,
+        })
 
 
 class FlexFieldsModelViewSet(FlexFieldsMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
Hi, Thanks for the nice repo.
While using it, I thought these changes will be help.
First, when expand a related object, add a select_related() to boost the query.
Second, strip  after a split to remove the blank character.

You can see it in the views.py