### PR TITLE
 docs(fix): readme code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To define an expandable field, add it to the ```expandable_fields``` within your
 ```
 class CountrySerializer(FlexFieldsModelSerializer):
     class Meta:
-        model = Company
+        model = Country
         fields = ['name', 'population']
 
 
@@ -127,7 +127,7 @@ class StateSerializer(FlexFieldsModelSerializer):
 
 class CountrySerializer(FlexFieldsModelSerializer):
     class Meta:
-        model = Company
+        model = Country
         fields = ['name', 'population']
 
     expandable_fields = {

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ class CountrySerializer(FlexFieldsModelSerializer):
         fields = ['name', 'population']
 
     expandable_fields = {
-        'states': (StateSerializer, {'source': 'country', 'many': True})
+        'states': (StateSerializer, {'source': 'states', 'many': True})
     }
 
 class PersonSerializer(FlexFieldsModelSerializer):

--- a/README.txt
+++ b/README.txt
@@ -104,7 +104,7 @@ within your serializer:
 
     class CountrySerializer(FlexFieldsModelSerializer):
         class Meta:
-            model = Company
+            model = Country
             fields = ['name', 'population']
 
 
@@ -172,7 +172,7 @@ country serializer above:
 
     class CountrySerializer(FlexFieldsModelSerializer):
         class Meta:
-            model = Company
+            model = Country
             fields = ['name', 'population']
 
         expandable_fields = {

--- a/README.txt
+++ b/README.txt
@@ -176,7 +176,7 @@ country serializer above:
             fields = ['name', 'population']
 
         expandable_fields = {
-            'states': (StateSerializer, {'source': 'country', 'many': True})
+            'states': (StateSerializer, {'source': 'state', 'many': True})
         }
 
     class PersonSerializer(FlexFieldsModelSerializer):


### PR DESCRIPTION
Please carefully review 3rd and 4th commits - since I'm not really sure, what `expandable_fields`'s `source` arg really means in this context.
(Can't find any documentation for that `source` and can't find its working in the sources either. DRF has a `source`, but it's for fields, not for serializers...)