### PR TITLE
handle request being 'None'

### DIFF
--- a/rest_flex_fields/serializers.py
+++ b/rest_flex_fields/serializers.py
@@ -106,7 +106,7 @@ class FlexFieldsModelSerializer(serializers.ModelSerializer):
         if self.parent:
             return False
         
-        if not hasattr(self, 'context') or 'request' not in self.context:
+        if not hasattr(self, 'context') or not self.context.get('request', None):
             return False 
         
         return self.context['request'].method == 'GET'


### PR DESCRIPTION
There are some cases, such as during serializer introspection for DRF's built in documentation tool, when `request` key is attached to a serializer context but is `None`. This change should handle all falsey cases.