### PR TITLE
Support different arrays in query string

### DIFF
--- a/rest_flex_fields/serializers.py
+++ b/rest_flex_fields/serializers.py
@@ -200,8 +200,13 @@ class FlexFieldsSerializerMixin(object):
         if not self._can_access_request:
             return []
 
-        value = self.context["request"].query_params.get(field)
-        return value.split(",") if value else []
+        values = self.context["request"].query_params.getlist(field)
+        if not values:
+            values = self.context["request"].query_params.getlist('{}[]'.format(field))
+
+        if values and len(values) == 1:
+            return values[0].split(",")
+        return values or []
 
     def _get_expand_input(self, passed_settings):
         """

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,6 +1,7 @@
 import unittest
 
 from rest_framework import serializers
+from django.utils.datastructures import MultiValueDict
 
 from rest_flex_fields import FlexFieldsModelSerializer
 from tests.testapp.models import Company, Person, Pet
@@ -141,7 +142,7 @@ class TestSerialize(unittest.TestCase):
                          employer=Company(name='McDonalds'))
         )
 
-        request = MockRequest(query_params={'expand': 'owner.employer'})
+        request = MockRequest(query_params=MultiValueDict({'expand': ['owner.employer']}))
         serializer = PetSerializer(pet, context={'request': request})
 
         self.assertEqual(serializer.data, {


### PR DESCRIPTION
fixes #39 

Currently flex-fields support passing lists of fields to expand/omit like this:
`?expand=field_1,field_2,field_3`

With this PR it will be possible to pass query strings like this:
```
?expand=field_1,field_2
?expand=field_1&expand=field_2
?expand[]=field_1&expand[]=field_2
```