### PR TITLE
Move field mods to to_representation and allows non-GET query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,11 @@ It will automatically call `select_related` and `prefetch_related` on the curren
 
 # Changelog <a id="changelog"></a>
 
+## 0.8.0 (April 2020)
+* Adds support for `expand`, `omit` and `fields` query parameters for non-GET requests.
+  - The common use case is creating/updating a model instance and returning a serialized response with expanded fields
+  - Thanks @kotepillar for raising the issue (#25) and @Crocmagnon for the idea of delaying field modification to `to_representation()`.
+
 ## 0.7.5 (February 2020)
 * Simplifies declaration of `expandable_fields`
   - If using a tuple, the second element - to define the serializer settings - is now optional.

--- a/rest_flex_fields/filter_backends.py
+++ b/rest_flex_fields/filter_backends.py
@@ -33,6 +33,8 @@ class FlexFieldsFilterBackend(BaseFilterBackend):
             context=view.get_serializer_context()
         )
 
+        serializer.apply_flex_fields()
+
         model_fields = [
             self._get_field(field.source, queryset.model)
             for field in serializer.fields.values()

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ classifiers = [
 ]
 setup(
     name="drf-flex-fields",
-    version="0.7.5",
+    version="0.8.0",
     description="Flexible, dynamic fields and nested resources for Django REST Framework serializers.",
     author="Robert Singer",
     author_email="robertgsinger@gmail.com",

--- a/tests/test_flex_fields_model_serializer.py
+++ b/tests/test_flex_fields_model_serializer.py
@@ -1,8 +1,6 @@
-from unittest.mock import MagicMock
 from unittest import TestCase
-from rest_framework import serializers
-from django.utils.datastructures import MultiValueDict
 
+from django.utils.datastructures import MultiValueDict
 from rest_flex_fields import FlexFieldsModelSerializer
 
 
@@ -35,116 +33,125 @@ class TestFlexFieldModelSerializer(TestCase):
     def test_clean_fields(self):
         serializer = FlexFieldsModelSerializer()
         serializer.fields = {"cat": 1, "dog": 2, "zebra": 3}
-        serializer._clean_fields(["cat"], [], {})
-        self.assertEqual(serializer.fields, {"dog": 2, "zebra": 3})
+        result = serializer._get_fields_names_to_remove(["cat"], [], {})
+        self.assertEqual(result, ["cat"])
 
-    def test_get_expanded_names_if_all(self):
+    def test_get_expanded_field_names_if_all(self):
         serializer = FlexFieldsModelSerializer()
         serializer.expandable_fields = {"cat": "field", "dog": "field"}
-        result = serializer._get_expanded_names("*", [], [], {})
+        result = serializer._get_expanded_field_names("*", [], [], {})
         self.assertEqual(result, ["cat", "dog"])
 
     def test_get_expanded_names_but_not_omitted(self):
         serializer = FlexFieldsModelSerializer()
         serializer.expandable_fields = {"cat": "field", "dog": "field"}
-        result = serializer._get_expanded_names(["cat", "dog"], ["cat"], [], {})
+        result = serializer._get_expanded_field_names(["cat", "dog"], ["cat"], [], {})
         self.assertEqual(result, ["dog"])
 
     def test_get_expanded_names_but_only_sparse(self):
         serializer = FlexFieldsModelSerializer()
         serializer.expandable_fields = {"cat": "field", "dog": "field"}
-        result = serializer._get_expanded_names(["cat"], [], ["cat"], {})
+        result = serializer._get_expanded_field_names(["cat"], [], ["cat"], {})
         self.assertEqual(result, ["cat"])
 
-    def test_get_expanded_names_even_omitted_when_defer_to_next_level(self):
+    def test_get_expanded_names_including_omitted_when_defer_to_next_level(self):
         serializer = FlexFieldsModelSerializer()
         serializer.expandable_fields = {"cat": "field", "dog": "field"}
-        result = serializer._get_expanded_names(["cat"], ["cat"], [], {"cat": ["age"]})
+        result = serializer._get_expanded_field_names(
+            ["cat"], ["cat"], [], {"cat": ["age"]}
+        )
         self.assertEqual(result, ["cat"])
 
-    def test_cannot_access_request_if_not_root_serializer(self):
-        serializer = FlexFieldsModelSerializer()
+    def test_get_query_param_value_should_return_empty_if_not_root_serializer(self):
+        serializer = FlexFieldsModelSerializer(
+            context={
+                "request": MockRequest(
+                    method="GET", query_params=MultiValueDict({"expand": ["cat"]})
+                )
+            },
+        )
         serializer.parent = "Another serializer here"
-        self.assertFalse(serializer._can_access_request)
-
-    def test_cannot_access_request_if_no_context(self):
-        serializer = FlexFieldsModelSerializer()
-        self.assertFalse(serializer._can_access_request)
-
-    def test_cannot_access_request_if_context_missing_request(self):
-        serializer = FlexFieldsModelSerializer(context={})
-        self.assertFalse(serializer._can_access_request)
+        self.assertFalse(serializer._get_query_param_value("expand"), [])
 
     def test_get_omit_input_from_explicit_settings(self):
-        serializer = FlexFieldsModelSerializer(context={})
-
-        serializer.context["request"] = MockRequest(
-            method="GET", query_params={"omit": "cat,dog"}
+        serializer = FlexFieldsModelSerializer(
+            omit=["fish"],
+            context={
+                "request": MockRequest(
+                    method="GET", query_params=MultiValueDict({"omit": "cat,dog"})
+                )
+            },
         )
 
-        result = serializer._get_omit_input(["fish"])
-        self.assertEqual(result, ["fish"])
+        self.assertEqual(serializer._flex_options["omit"], ["fish"])
 
-    def test_get_omit_input_from_query_param(self):
-        serializer = FlexFieldsModelSerializer(context={})
+    def test_set_omit_input_from_query_param(self):
+        serializer = FlexFieldsModelSerializer(
+            context={
+                "request": MockRequest(
+                    method="GET", query_params=MultiValueDict({"omit": ["cat,dog"]})
+                )
+            }
+        )
+        self.assertEqual(serializer._flex_options["omit"], ["cat", "dog"])
 
-        serializer.context["request"] = MockRequest(
-            method="GET", query_params=MultiValueDict({"omit": ["cat,dog"]})
+    def test_set_fields_input_from_explicit_settings(self):
+        serializer = FlexFieldsModelSerializer(
+            fields=["fish"],
+            context={
+                "request": MockRequest(
+                    method="GET", query_params=MultiValueDict({"fields": "cat,dog"})
+                )
+            },
         )
 
-        result = serializer._get_omit_input([])
-        self.assertEqual(result, ["cat", "dog"])
+        self.assertEqual(serializer._flex_options["fields"], ["fish"])
 
-    def test_get_fields_input_from_explicit_settings(self):
-        serializer = FlexFieldsModelSerializer(context={})
-
-        serializer.context["request"] = MockRequest(
-            method="GET", query_params={"fields": "cat,dog"}
+    def test_set_fields_input_from_query_param(self):
+        serializer = FlexFieldsModelSerializer(
+            context={
+                "request": MockRequest(
+                    method="GET", query_params=MultiValueDict({"fields": ["cat,dog"]})
+                )
+            }
         )
 
-        result = serializer._get_fields_input(["fish"])
-        self.assertEqual(result, ["fish"])
+        self.assertEqual(serializer._flex_options["fields"], ["cat", "dog"])
 
-    def test_get_fields_input_from_query_param(self):
-        serializer = FlexFieldsModelSerializer(context={})
-
-        serializer.context["request"] = MockRequest(
-            method="GET", query_params=MultiValueDict({"fields": ["cat,dog"]})
+    def test_set_expand_input_from_explicit_setting(self):
+        serializer = FlexFieldsModelSerializer(
+            fields=["cat"],
+            context={
+                "request": MockRequest(
+                    method="GET", query_params=MultiValueDict({"fields": "cat,dog"})
+                )
+            },
         )
 
-        result = serializer._get_fields_input([])
-        self.assertEqual(result, ["cat", "dog"])
+        self.assertEqual(serializer._flex_options["fields"], ["cat"])
 
-    def test_get_expand_input_from_explicit_setting(self):
-        serializer = FlexFieldsModelSerializer(context={})
-
-        serializer.context["request"] = MockRequest(
-            method="GET", query_params={"fields": "cat,dog"}
+    def test_set_expand_input_from_query_param(self):
+        serializer = FlexFieldsModelSerializer(
+            context={
+                "request": MockRequest(
+                    method="GET", query_params=MultiValueDict({"expand": ["cat,dog"]})
+                )
+            }
         )
 
-        result = serializer._get_expand_input(["cat"])
-        self.assertEqual(result, ["cat"])
-
-    def test_get_expand_input_from_query_param(self):
-        serializer = FlexFieldsModelSerializer(context={})
-
-        serializer.context["request"] = MockRequest(
-            method="GET", query_params=MultiValueDict({"expand": ["cat,dog"]})
-        )
-
-        result = serializer._get_expand_input([])
-        self.assertEqual(result, ["cat", "dog"])
+        self.assertEqual(serializer._flex_options["expand"], ["cat", "dog"])
 
     def test_get_expand_input_from_query_param_limit_to_list_permitted(self):
-        serializer = FlexFieldsModelSerializer(context={})
-
-        serializer.context["request"] = MockRequest(
-            method="GET", query_params=MultiValueDict({"expand": ["cat,dog"]})
+        serializer = FlexFieldsModelSerializer(
+            context={
+                "request": MockRequest(
+                    method="GET", query_params=MultiValueDict({"expand": ["cat,dog"]})
+                ),
+                "permitted_expands": ["cat"],
+            }
         )
 
-        serializer.context["permitted_expands"] = ["cat"]
-        result = serializer._get_expand_input([])
-        self.assertEqual(result, ["cat"])
+        self.assertEqual(serializer._flex_options["expand"], ["cat"])
 
     def test_parse_request_list_value(self):
         test_params = [
@@ -158,12 +165,12 @@ class TestFlexFieldModelSerializer(TestCase):
                 method="GET", query_params=MultiValueDict(query_params)
             )
 
-            result = serializer._parse_request_list_value("abc")
+            result = serializer._get_query_param_value("abc")
             self.assertEqual(result, ["cat", "dog", "mouse"])
 
     def test_parse_request_list_value_empty_if_cannot_access_request(self):
         serializer = FlexFieldsModelSerializer(context={})
-        result = serializer._parse_request_list_value("abc")
+        result = serializer._get_query_param_value("abc")
         self.assertEqual(result, [])
 
     def test_import_serializer_class(self):

--- a/tests/test_flex_fields_model_serializer.py
+++ b/tests/test_flex_fields_model_serializer.py
@@ -75,18 +75,6 @@ class TestFlexFieldModelSerializer(TestCase):
         serializer = FlexFieldsModelSerializer(context={})
         self.assertFalse(serializer._can_access_request)
 
-    def test_cannot_access_request_if_request_method_is_not_get(self):
-        serializer = FlexFieldsModelSerializer(
-            context={"request": MockRequest(method="PUT")}
-        )
-        self.assertFalse(serializer._can_access_request)
-
-    def test_can_access_request_if_request_method_is_get(self):
-        serializer = FlexFieldsModelSerializer(
-            context={"request": MockRequest(method="GET")}
-        )
-        self.assertTrue(serializer._can_access_request)
-
     def test_get_omit_input_from_explicit_settings(self):
         serializer = FlexFieldsModelSerializer(context={})
 
@@ -94,7 +82,7 @@ class TestFlexFieldModelSerializer(TestCase):
             method="GET", query_params={"omit": "cat,dog"}
         )
 
-        result = serializer._get_omit_input({"omit": ["fish"]})
+        result = serializer._get_omit_input(["fish"])
         self.assertEqual(result, ["fish"])
 
     def test_get_omit_input_from_query_param(self):
@@ -104,7 +92,7 @@ class TestFlexFieldModelSerializer(TestCase):
             method="GET", query_params=MultiValueDict({"omit": ["cat,dog"]})
         )
 
-        result = serializer._get_omit_input({"omit": []})
+        result = serializer._get_omit_input([])
         self.assertEqual(result, ["cat", "dog"])
 
     def test_get_fields_input_from_explicit_settings(self):
@@ -114,7 +102,7 @@ class TestFlexFieldModelSerializer(TestCase):
             method="GET", query_params={"fields": "cat,dog"}
         )
 
-        result = serializer._get_fields_input({"fields": ["fish"]})
+        result = serializer._get_fields_input(["fish"])
         self.assertEqual(result, ["fish"])
 
     def test_get_fields_input_from_query_param(self):
@@ -124,7 +112,7 @@ class TestFlexFieldModelSerializer(TestCase):
             method="GET", query_params=MultiValueDict({"fields": ["cat,dog"]})
         )
 
-        result = serializer._get_fields_input({"fields": []})
+        result = serializer._get_fields_input([])
         self.assertEqual(result, ["cat", "dog"])
 
     def test_get_expand_input_from_explicit_setting(self):
@@ -134,7 +122,7 @@ class TestFlexFieldModelSerializer(TestCase):
             method="GET", query_params={"fields": "cat,dog"}
         )
 
-        result = serializer._get_expand_input({"expand": ["cat"]})
+        result = serializer._get_expand_input(["cat"])
         self.assertEqual(result, ["cat"])
 
     def test_get_expand_input_from_query_param(self):
@@ -144,7 +132,7 @@ class TestFlexFieldModelSerializer(TestCase):
             method="GET", query_params=MultiValueDict({"expand": ["cat,dog"]})
         )
 
-        result = serializer._get_expand_input({"expand": []})
+        result = serializer._get_expand_input([])
         self.assertEqual(result, ["cat", "dog"])
 
     def test_get_expand_input_from_query_param_limit_to_list_permitted(self):
@@ -155,7 +143,7 @@ class TestFlexFieldModelSerializer(TestCase):
         )
 
         serializer.context["permitted_expands"] = ["cat"]
-        result = serializer._get_expand_input({"expand": []})
+        result = serializer._get_expand_input([])
         self.assertEqual(result, ["cat"])
 
     def test_parse_request_list_value(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -79,6 +79,31 @@ class PetViewTests(APITestCase):
             },
         )
 
+    def test_create_and_return_expanded_field(self):
+        url = reverse("pet-list")
+        url = url + "?expand=owner"
+
+        response = self.client.post(
+            url,
+            {
+                "owner": self.person.id,
+                "species": "snake",
+                "toys": "playstation",
+                "name": "Freddy",
+            },
+            format="json",
+        )
+
+        self.assertEqual(
+            response.data,
+            {
+                "name": "Freddy",
+                "toys": "playstation",
+                "species": "snake",
+                "owner": {"name": "Fred", "hobbies": "sailing"},
+            },
+        )
+
 
 @override_settings(DEBUG=True)
 @patch("tests.testapp.views.PetViewSet.filter_backends", [FlexFieldsFilterBackend])

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -2,18 +2,15 @@ from __future__ import unicode_literals
 from django.db import models
 
 
-
 class Company(models.Model):
     name = models.CharField(max_length=30)
     public = models.BooleanField(default=False)
-
 
 
 class Person(models.Model):
     name = models.CharField(max_length=30)
     hobbies = models.CharField(max_length=30)
     employer = models.ForeignKey(Company, on_delete=models.CASCADE)
-
 
 
 class Pet(models.Model):


### PR DESCRIPTION
Refactoring to move field modifications to `to_representation`. 

Also allows using query parameters to alter fields with non-GET requests. 