### PR TITLE
Upgrade Django to v3.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 appdirs==1.4.3
-asgiref==3.2.3
 attrs==19.1.0
 black==19.3b0
 Click==7.0
-Django==3.0.7
-djangorestframework==3.11.0
+Django==3.1.1
+djangorestframework==3.12.1
 entrypoints==0.3
 flake8==3.7.7
 mccabe==0.6.1

--- a/rest_flex_fields/filter_backends.py
+++ b/rest_flex_fields/filter_backends.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from typing import Optional
 
+from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models import QuerySet
 from rest_framework.compat import coreapi, coreschema
@@ -85,7 +86,7 @@ class FlexFieldsFilterBackend(BaseFilterBackend):
         try:
             # noinspection PyProtectedMember
             return model._meta.get_field(field_name)
-        except models.FieldDoesNotExist:
+        except FieldDoesNotExist:
             return None
 
     def get_schema_fields(self, view):


### PR DESCRIPTION
Upgraded Django to 3.1.1
Fixed models.FieldDoesNotExist, compatibility import of django.core.exceptions.FieldDoesNotExist in django.db.models.fields is removed.