### PR TITLE
get_schema_operation_parameters method for OpenAPI support

### DIFF
--- a/rest_flex_fields/filter_backends.py
+++ b/rest_flex_fields/filter_backends.py
@@ -132,3 +132,46 @@ class FlexFieldsFilterBackend(BaseFilterBackend):
                 example="nested1,nested2",
             ),
         ]
+
+    def get_schema_operation_parameters(self, view):
+
+        if not issubclass(view.get_serializer_class(), FlexFieldsSerializerMixin):
+            return []
+
+        parameters = [
+            {
+                "name": "fields",
+                "required": False,
+                "in": "query",
+                "description": "Specify required field by comma",
+                "schema": {
+                    "title": "Selected fields",
+                    "type": "string",
+                },
+                "example": "field1,field2,nested.field",
+            },
+            {
+                "name": "omit",
+                "required": False,
+                "in": "query",
+                "description": "Specify required field by comma",
+                "schema": {
+                    "title": "Omitted fields",
+                    "type": "string",
+                },
+                "example": "field1,field2,nested.field",
+            },
+            {
+                "name": "expand",
+                "required": False,
+                "in": "query",
+                "description": "Specify required field by comma",
+                "schema": {
+                    "title": "Expanded fields",
+                    "type": "string",
+                },
+                "example": "nested1,nested2",
+            },
+        ]
+
+        return parameters


### PR DESCRIPTION
A method to add OpenAPI schema generation support. As CoreAPI code will be fully removed in DRF 3.12+.
https://www.django-rest-framework.org/coreapi/