### PR TITLE
Upgrade to Django 3.2 and fix warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ asgiref==3.4.1
 attrs==19.1.0
 black==19.3b0
 Click==7.0
-Django==3.1.12
+Django==3.2
 djangorestframework==3.12.1
 entrypoints==0.3
 flake8==3.7.7

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -115,3 +115,9 @@ STATIC_URL = "/static/"
 
 
 REST_FLEX_FIELDS = {"EXPAND_PARAM": "expand"}
+
+# In Django 3.2 and onwards, the primary keys are generated using `BigAutoField` instead
+# of `AutoField`. To avoid introducing migrations and silence the configuration warnings,
+# we're setting this to `AutoField`, which is ok for this use case (tests).
+# Reference: https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/tests/testapp/apps.py
+++ b/tests/testapp/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class TestappConfig(AppConfig):
-    name = 'testapp'
+    name = 'tests.testapp'


### PR DESCRIPTION
Related to https://github.com/rsinger86/drf-flex-fields/issues/82.

I've upgraded Django to 3.2, fixed the deprecation warning, and ran tests. 
I didn't change anything in the library itself, but had to make a few minor adjustments to the tests:

**Django 3.2:**
```
> ./manage.py test
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.....................................................
----------------------------------------------------------------------
Ran 53 tests in 0.130s

OK
Destroying test database for alias 'default'...
```

**Django 3.1:**
```
> ./manage.py test
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.....................................................
----------------------------------------------------------------------
Ran 53 tests in 0.134s

OK
Destroying test database for alias 'default'...
```

**Django 2.2:**
```
> ./manage.py test
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.....................................................
----------------------------------------------------------------------
Ran 53 tests in 0.127s

OK
Destroying test database for alias 'default'...
```



