### PR TITLE
Dummy filter backend for docs

### DIFF
--- a/rest_flex_fields/filter_backends.py
+++ b/rest_flex_fields/filter_backends.py
@@ -24,84 +24,14 @@ from rest_flex_fields.serializers import (
 )
 
 
-class FlexFieldsFilterBackend(BaseFilterBackend):
-    def filter_queryset(
-        self, request: Request, queryset: QuerySet, view: GenericViewSet
-    ):
-        if (
-            not issubclass(view.get_serializer_class(), FlexFieldsSerializerMixin)
-            or request.method != "GET"
-        ):
-            return queryset
-
-        auto_remove_fields_from_query = getattr(
-            view, "auto_remove_fields_from_query", True
-        )
-        auto_select_related_on_query = getattr(
-            view, "auto_select_related_on_query", True
-        )
-        required_query_fields = list(getattr(view, "required_query_fields", []))
-
-        serializer = view.get_serializer(  # type: FlexFieldsSerializerMixin
-            context=view.get_serializer_context()
-        )
-
-        serializer.apply_flex_fields(
-            serializer.fields, serializer._flex_options_rep_only
-        )
-        serializer._flex_fields_rep_applied = True
-
-        model_fields = []
-        nested_model_fields = []
-        for field in serializer.fields.values():
-            model_field = self._get_field(field.source, queryset.model)
-            if model_field:
-                model_fields.append(model_field)
-                if field.field_name in serializer.expanded_fields or (
-                    model_field.is_relation and not model_field.many_to_one
-                ):
-                    nested_model_fields.append(model_field)
-
-        if auto_remove_fields_from_query:
-            queryset = queryset.only(
-                *(
-                    required_query_fields
-                    + [
-                        model_field.name
-                        for model_field in model_fields
-                        if not model_field.is_relation or model_field.many_to_one
-                    ]
-                )
-            )
-
-        if auto_select_related_on_query and nested_model_fields:
-            queryset = queryset.select_related(
-                *(
-                    model_field.name
-                    for model_field in nested_model_fields
-                    if model_field.is_relation and model_field.many_to_one
-                )
-            )
-
-            queryset = queryset.prefetch_related(
-                *(
-                    model_field.name
-                    for model_field in nested_model_fields
-                    if model_field.is_relation and not model_field.many_to_one
-                )
-            )
-
+class FlexFieldsDocsFilterBackend(BaseFilterBackend):
+    """
+    A dummy filter backend only for schema/documentation purposes.
+    """
+    
+    def filter_queryset(self, request, queryset, view):
         return queryset
 
-    @staticmethod
-    @lru_cache()
-    def _get_field(field_name: str, model: models.Model) -> Optional[models.Field]:
-        try:
-            # noinspection PyProtectedMember
-            return model._meta.get_field(field_name)
-        except FieldDoesNotExist:
-            return None
-    
     @staticmethod
     def _get_expandable_fields(serializer_class: FlexFieldsModelSerializer) -> str:
         expandable_fields = getattr(serializer_class.Meta, "expandable_fields", {})
@@ -114,10 +44,10 @@ class FlexFieldsFilterBackend(BaseFilterBackend):
 
     def get_schema_fields(self, view):
         assert (
-            coreapi is not None
+                coreapi is not None
         ), "coreapi must be installed to use `get_schema_fields()`"
         assert (
-            coreschema is not None
+                coreschema is not None
         ), "coreschema must be installed to use `get_schema_fields()`"
 
         serializer_class = view.get_serializer_class()
@@ -205,3 +135,82 @@ class FlexFieldsFilterBackend(BaseFilterBackend):
         ]
 
         return parameters
+
+
+class FlexFieldsFilterBackend(FlexFieldsDocsFilterBackend):
+    def filter_queryset(
+        self, request: Request, queryset: QuerySet, view: GenericViewSet
+    ):
+        if (
+            not issubclass(view.get_serializer_class(), FlexFieldsSerializerMixin)
+            or request.method != "GET"
+        ):
+            return queryset
+
+        auto_remove_fields_from_query = getattr(
+            view, "auto_remove_fields_from_query", True
+        )
+        auto_select_related_on_query = getattr(
+            view, "auto_select_related_on_query", True
+        )
+        required_query_fields = list(getattr(view, "required_query_fields", []))
+
+        serializer = view.get_serializer(  # type: FlexFieldsSerializerMixin
+            context=view.get_serializer_context()
+        )
+
+        serializer.apply_flex_fields(
+            serializer.fields, serializer._flex_options_rep_only
+        )
+        serializer._flex_fields_rep_applied = True
+
+        model_fields = []
+        nested_model_fields = []
+        for field in serializer.fields.values():
+            model_field = self._get_field(field.source, queryset.model)
+            if model_field:
+                model_fields.append(model_field)
+                if field.field_name in serializer.expanded_fields or (
+                    model_field.is_relation and not model_field.many_to_one
+                ):
+                    nested_model_fields.append(model_field)
+
+        if auto_remove_fields_from_query:
+            queryset = queryset.only(
+                *(
+                    required_query_fields
+                    + [
+                        model_field.name
+                        for model_field in model_fields
+                        if not model_field.is_relation or model_field.many_to_one
+                    ]
+                )
+            )
+
+        if auto_select_related_on_query and nested_model_fields:
+            queryset = queryset.select_related(
+                *(
+                    model_field.name
+                    for model_field in nested_model_fields
+                    if model_field.is_relation and model_field.many_to_one
+                )
+            )
+
+            queryset = queryset.prefetch_related(
+                *(
+                    model_field.name
+                    for model_field in nested_model_fields
+                    if model_field.is_relation and not model_field.many_to_one
+                )
+            )
+
+        return queryset
+
+    @staticmethod
+    @lru_cache()
+    def _get_field(field_name: str, model: models.Model) -> Optional[models.Field]:
+        try:
+            # noinspection PyProtectedMember
+            return model._meta.get_field(field_name)
+        except FieldDoesNotExist:
+            return None


### PR DESCRIPTION
This PR implements the idea described in https://github.com/rsinger86/drf-flex-fields/issues/98 and provides a `FlexFieldsDocsFilterBackend` that only populates the schema and otherwise does no filtering.

Based off https://github.com/rsinger86/drf-flex-fields/pull/99, so only merge if that one is merged, alternatively let me know and I can rework the PR and base it off `master`.