### PR TITLE
Fix #104, FlexFieldsFilterBackend now handles GenericForeignKey correctly

### DIFF
--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
 
@@ -24,3 +27,10 @@ class Pet(models.Model):
     owner = models.ForeignKey(Person, on_delete=models.CASCADE)
     sold_from = models.ForeignKey(PetStore, null=True, on_delete=models.CASCADE)
     diet = models.CharField(max_length=200)
+
+
+class TaggedItem(models.Model):
+    tag = models.SlugField()
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
+    object_id = models.PositiveIntegerField()
+    content_object = GenericForeignKey('content_type', 'object_id')

--- a/tests/testapp/serializers.py
+++ b/tests/testapp/serializers.py
@@ -1,6 +1,8 @@
 from rest_framework import serializers
+from rest_framework.relations import PrimaryKeyRelatedField
+
 from rest_flex_fields import FlexFieldsModelSerializer
-from tests.testapp.models import Pet, PetStore, Person, Company
+from tests.testapp.models import Pet, PetStore, Person, Company, TaggedItem
 
 
 class CompanySerializer(FlexFieldsModelSerializer):
@@ -43,3 +45,16 @@ class PetSerializer(FlexFieldsModelSerializer):
         if obj.name == "Garfield":
             return "homemade lasanga"
         return "pet food"
+
+
+class TaggedItemSerializer(FlexFieldsModelSerializer):
+    content_object = PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = TaggedItem
+        fields = (
+            "id",
+            "content_type",
+            "object_id",
+            "content_object"
+        )

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -1,6 +1,8 @@
+from rest_framework.viewsets import ModelViewSet
+
 from rest_flex_fields import FlexFieldsModelViewSet
-from tests.testapp.models import Pet
-from tests.testapp.serializers import PetSerializer
+from tests.testapp.models import Pet, TaggedItem
+from tests.testapp.serializers import PetSerializer, TaggedItemSerializer
 
 
 class PetViewSet(FlexFieldsModelViewSet):
@@ -11,3 +13,8 @@ class PetViewSet(FlexFieldsModelViewSet):
     serializer_class = PetSerializer
     queryset = Pet.objects.all()
     permit_list_expands = ["owner"]
+
+
+class TaggedItemViewSet(ModelViewSet):
+    serializer_class = TaggedItemSerializer
+    queryset = TaggedItem.objects.all()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,10 +1,10 @@
 from django.conf.urls import url, include
 from rest_framework import routers
-from tests.testapp.views import PetViewSet
-
+from tests.testapp.views import PetViewSet, TaggedItemViewSet
 
 # Standard viewsets
 router = routers.DefaultRouter()
 router.register(r"pets", PetViewSet, basename="pet")
+router.register(r"tagged-items", TaggedItemViewSet, basename="tagged-item")
 
 urlpatterns = [url(r"^", include(router.urls))]


### PR DESCRIPTION
Fix #104, FlexFieldsFilterBackend now handles GenericForeignKey correctly by routing it into the prefetch_related fields.