### PR TITLE
add prefetch ignores

### DIFF
--- a/rest_flex_fields/filter_backends.py
+++ b/rest_flex_fields/filter_backends.py
@@ -227,12 +227,18 @@ class FlexFieldsFilterBackend(FlexFieldsDocsFilterBackend):
 
             queryset = queryset.prefetch_related(*(
                 model_field.name for model_field in nested_model_fields if
-                (model_field.is_relation and not model_field.many_to_one) or
-                (model_field.is_relation and model_field.many_to_one and not model_field.concrete)  # Include GenericForeignKey)
+                (
+                    (model_field.is_relation and not model_field.many_to_one) or
+                    (model_field.is_relation and model_field.many_to_one and not model_field.concrete)  # Include GenericForeignKey)
+                ) and
+                    (model_field.name not in self._get_prefetches_ignores())
                 )
             )
 
         return queryset
+
+    def _get_prefetches_ignores(self):
+        return []
 
     @staticmethod
     @lru_cache()


### PR DESCRIPTION
I've got a situation where I need to define the Prefetch in a Filter because the filter applies to a prefetched field.  I think the best way to facilitate that kind of a situation is to allow for prefetch ignores that don't get created procedurally.  Might be helpful to others.