### PR TITLE
Add `FlexSerializerMethodField`

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,10 +439,10 @@ from rest_flex_fields.serializers import FlexFieldsModelSerializer, FlexFieldsSe
 from rest_flex_fields.fields import FlexSerializerMethodField
 
 
-class EventSerializer(serializers.Serializer, FlexFieldsSerializerMixin):
-    class Meta:
-        model = Event
-        fields = ["name", "city", "tickets"]
+class EventSerializer(FlexFieldsSerializerMixin, serializers.Serializer):
+    name = serializers.CharField()
+    city = serializers.CharField()
+    tickets = serializers.CharField()
 
 class CountrySerializer(FlexFieldsModelSerializer):
     events = FlexSerializerMethodField()

--- a/README.md
+++ b/README.md
@@ -429,6 +429,91 @@ print(serializer.data)
 }
 ```
 
+## Serializer Method Fields
+
+If you want support for nested `expand`, `omit` and `fields` query args in `SerializerMethodField` fields, use `FlexSerializerMethodField`. This can be usefull for serializing iterables that are not related to your original model. For example:
+
+```python
+from rest_framework import serializers
+from rest_flex_fields.serializers import FlexFieldsModelSerializer, FlexFieldsSerializerMixin
+from rest_flex_fields.fields import FlexSerializerMethodField
+
+
+class EventSerializer(serializers.Serializer, FlexFieldsSerializerMixin):
+    class Meta:
+        model = Event
+        fields = ["name", "city", "tickets"]
+
+class CountrySerializer(FlexFieldsModelSerializer):
+    events = FlexSerializerMethodField()
+
+    class Meta:
+        model = Country
+        fields = ['name', 'events']
+
+    def get_events(self, obj, expand, omit, fields):
+        events = get_event_list(country=obj) # get events from some external api or something like that
+        return EventSerializer(events, many=True, expand=expand, omit=omit, fields=fields).data
+```
+
+Default `GET /country_events`:
+
+```json
+[
+  {
+    "name": "Germany",
+    "events": [
+      {
+        "name": "Wacken Open Air",
+        "city": "Wacken",
+        "tickets": "www.example.com/wacken"
+      },
+      {
+        "name": "Full Force",
+        "city": "Grafenhainichen",
+        "tickets": "www.example.com/full_force"
+      }
+    ]
+  },
+  {
+    "name": "Spain",
+    "events": [
+      {
+        "name": "Resurrection",
+        "city": "Viveiro",
+        "tickets": "www.example.com/resurrection"
+      }
+    ]
+  }
+]
+```
+
+You can then use query args to filter the `events` fields. `GET /country_events?fields=name,events.name`:
+
+```json
+[
+  {
+    "name": "Germany",
+    "events": [
+      {
+        "name": "Wacken Open Air"
+      },
+      {
+        "name": "Full Force"
+      }
+    ]
+  },
+  {
+    "name": "Spain",
+    "events": [
+      {
+        "name": "Resurrection"
+      }
+    ]
+  }
+]
+```
+
 # Serializer Options
 
 Dynamic field options can be passed in the following ways:
@@ -484,9 +569,9 @@ class PersonSerializer(FlexFieldsModelSerializer):
 Parameter names and wildcard values can be configured within a Django setting, named `REST_FLEX_FIELDS`.
 
 | Option                        |                                                                                                                                                                                                                                                                         Description                                                                                                                                                                                                                                                                          | Default         |
-|-------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|-----------------|
+| ----------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | --------------- |
 | EXPAND_PARAM                  |                                                                                                                                                                                                                                                   The name of the parameter with the fields to be expanded                                                                                                                                                                                                                                                   | `"expand"`      |
-| MAXIMUM_EXPANSION_DEPTH       |                                                                                                                                                                                                                                                      The max allowed expansion depth. By default it's unlimited. Expanding `state.towns` would equal a depth of 2                                                                                                                                                                                                                                            | `None`          |
+| MAXIMUM_EXPANSION_DEPTH       |                                                                                                                                                                                                                         The max allowed expansion depth. By default it's unlimited. Expanding `state.towns` would equal a depth of 2                                                                                                                                                                                                                         | `None`          |
 | FIELDS_PARAM                  |                                                                                                                                                                                                                                      The name of the parameter with the fields to be included (others will be omitted)                                                                                                                                                                                                                                       | `"fields"`      |
 | OMIT_PARAM                    |                                                                                                                                                                                                                                                   The name of the parameter with the fields to be omitted                                                                                                                                                                                                                                                    | `"omit"`        |
 | RECURSIVE_EXPANSION_PERMITTED |                                                                                                                                                                                                                                             If `False`, an exception is raised when a recursive pattern is found                                                                                                                                                                                                                                             | `True`          |
@@ -504,8 +589,7 @@ A `maximum_expansion_depth` integer property can be set on a serializer class.
 
 `recursive_expansion_permitted` boolean property can be set on a serializer class.
 
-Both settings raise `serializers.ValidationError` when conditions are met but exceptions can be customized by overriding the `recursive_expansion_not_permitted` and `expansion_depth_exceeded` methods. 
-
+Both settings raise `serializers.ValidationError` when conditions are met but exceptions can be customized by overriding the `recursive_expansion_not_permitted` and `expansion_depth_exceeded` methods.
 
 ## Serializer Introspection
 
@@ -583,6 +667,10 @@ It will automatically call `select_related` and `prefetch_related` on the curren
 **WARNING:** The optimization currently works only for one nesting level.
 
 # Changelog <a id="changelog"></a>
+
+## Unreleased
+
+- Adds `FlexSerializerMethodField`.
 
 ## 1.0.2 (March 2023)
 

--- a/rest_flex_fields/fields.py
+++ b/rest_flex_fields/fields.py
@@ -1,0 +1,4 @@
+from rest_framework import serializers
+
+class FlexSerializerMethodField(serializers.SerializerMethodField):
+    ...

--- a/rest_flex_fields/fields.py
+++ b/rest_flex_fields/fields.py
@@ -1,4 +1,12 @@
 from rest_framework import serializers
 
 class FlexSerializerMethodField(serializers.SerializerMethodField):
-    ...
+    def __init__(self, method_name=None, **kwargs):
+        self.expand = kwargs.pop("expand", [])
+        self.fields = kwargs.pop("fields", [])
+        self.omit = kwargs.pop("omit", [])
+        super().__init__(method_name, **kwargs)
+
+    def to_representation(self, value):
+        method = getattr(self.parent, self.method_name)
+        return method(value, self.fields, self.expand, self.omit)

--- a/rest_flex_fields/serializers.py
+++ b/rest_flex_fields/serializers.py
@@ -13,6 +13,7 @@ from rest_flex_fields import (
     RECURSIVE_EXPANSION_PERMITTED,
     split_levels,
 )
+from .fields import FlexSerializerMethodField
 
 
 class FlexFieldsSerializerMixin(object):
@@ -132,8 +133,9 @@ class FlexFieldsSerializerMixin(object):
         if issubclass(serializer_class, serializers.Serializer):
             settings["context"] = self.context
 
-        if issubclass(serializer_class, FlexFieldsSerializerMixin):
-            settings["parent"] = self
+        if issubclass(serializer_class, (FlexFieldsSerializerMixin, FlexSerializerMethodField)):
+            if issubclass(serializer_class, FlexFieldsSerializerMixin):
+                settings["parent"] = self
 
             if name in nested_expand:
                 settings[EXPAND_PARAM] = nested_expand[name]

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,0 +1,109 @@
+from django.test import TestCase
+from django.urls import reverse
+from tests.testapp.models import Country
+
+
+class TestFlexSerializerMethodField(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        Country.objects.create(name="Germany")
+        Country.objects.create(name="Spain")
+        return super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        Country.objects.all().delete()
+        return super().tearDownClass()
+
+    def setUp(self) -> None:
+        self.url = reverse("country-events-list")
+        return super().setUp()
+
+    def test_filtering_events_fields(self):
+        r = self.client.get(self.url)
+
+        self.assertListEqual(
+            r.json(),
+            [
+                {
+                    "name": "Germany",
+                    "events": [
+                        {
+                            "name": "Wacken Open Air",
+                            "city": "Wacken",
+                            "tickets": "www.example.com/wacken"
+                        },
+                        {
+                            "name": "Full Force",
+                            "city": "Grafenhainichen",
+                            "tickets": "www.example.com/full_force"
+                        }
+                    ]
+                },
+                {
+                    "name": "Spain",
+                    "events": [
+                        {
+                            "name": "Resurrection",
+                            "city": "Viveiro",
+                            "tickets": "www.example.com/resurrection"
+                        }
+                    ]
+                }
+            ]
+        )
+
+        r = self.client.get(self.url+"?fields=name,events.name")
+        self.assertListEqual(
+            r.json(),
+            [
+                {
+                    "name": "Germany",
+                    "events": [
+                        {
+                            "name": "Wacken Open Air"
+                        },
+                        {
+                            "name": "Full Force"
+                        }
+                    ]
+                },
+                {
+                    "name": "Spain",
+                    "events": [
+                        {
+                            "name": "Resurrection"
+                        }
+                    ]
+                }
+            ]
+        )
+
+        r = self.client.get(self.url+"?omit=events.tickets")
+        self.assertListEqual(
+            r.json(),
+            [
+                {
+                    "name": "Germany",
+                    "events": [
+                        {
+                            "name": "Wacken Open Air",
+                            "city": "Wacken",
+                        },
+                        {
+                            "name": "Full Force",
+                            "city": "Grafenhainichen",
+                        }
+                    ]
+                },
+                {
+                    "name": "Spain",
+                    "events": [
+                        {
+                            "name": "Resurrection",
+                            "city": "Viveiro",
+                        }
+                    ]
+                }
+            ]
+        )

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -27,34 +27,15 @@ class TestFlexSerializerMethodField(TestCase):
             [
                 {
                     "name": "Germany",
-                    "events": [
-                        {
-                            "name": "Wacken Open Air",
-                            "city": "Wacken",
-                            "tickets": "www.example.com/wacken"
-                        },
-                        {
-                            "name": "Full Force",
-                            "city": "Grafenhainichen",
-                            "tickets": "www.example.com/full_force"
-                        }
-                    ]
                 },
                 {
                     "name": "Spain",
-                    "events": [
-                        {
-                            "name": "Resurrection",
-                            "city": "Viveiro",
-                            "tickets": "www.example.com/resurrection"
-                        }
-                    ]
                 }
             ]
         )
 
     def test_omit_arg(self):
-        r = self.client.get(self.url+"?omit=name,events.tickets")
+        r = self.client.get(self.url+"?omit=name,events.tickets&expand=events")
         self.assertListEqual(
             r.json(),
             [
@@ -82,7 +63,7 @@ class TestFlexSerializerMethodField(TestCase):
         )
 
     def test_fields_arg(self):
-        r = self.client.get(self.url+"?fields=name,events.name")
+        r = self.client.get(self.url+"?fields=name,events.name&expand=events")
         self.assertListEqual(
             r.json(),
             [

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -19,7 +19,7 @@ class TestFlexSerializerMethodField(TestCase):
         self.url = reverse("country-events-list")
         return super().setUp()
 
-    def test_filtering_events_fields(self):
+    def test_base_request(self):
         r = self.client.get(self.url)
 
         self.assertListEqual(
@@ -53,6 +53,35 @@ class TestFlexSerializerMethodField(TestCase):
             ]
         )
 
+    def test_omit_arg(self):
+        r = self.client.get(self.url+"?omit=name,events.tickets")
+        self.assertListEqual(
+            r.json(),
+            [
+                {
+                    "events": [
+                        {
+                            "name": "Wacken Open Air",
+                            "city": "Wacken",
+                        },
+                        {
+                            "name": "Full Force",
+                            "city": "Grafenhainichen",
+                        }
+                    ]
+                },
+                {
+                    "events": [
+                        {
+                            "name": "Resurrection",
+                            "city": "Viveiro",
+                        }
+                    ]
+                }
+            ]
+        )
+
+    def test_fields_arg(self):
         r = self.client.get(self.url+"?fields=name,events.name")
         self.assertListEqual(
             r.json(),
@@ -79,20 +108,27 @@ class TestFlexSerializerMethodField(TestCase):
             ]
         )
 
-        r = self.client.get(self.url+"?omit=events.tickets")
+    def test_expand_arg(self):
+        r = self.client.get(self.url+"?expand=events.city")
         self.assertListEqual(
             r.json(),
-            [
+                [
                 {
                     "name": "Germany",
                     "events": [
                         {
                             "name": "Wacken Open Air",
-                            "city": "Wacken",
+                            "city": {
+                                "name": "Wacken",
+                            },
+                            "tickets": "www.example.com/wacken"
                         },
                         {
                             "name": "Full Force",
-                            "city": "Grafenhainichen",
+                            "city": {
+                                "name": "Grafenhainichen",
+                            },
+                            "tickets": "www.example.com/full_force"
                         }
                     ]
                 },
@@ -101,9 +137,13 @@ class TestFlexSerializerMethodField(TestCase):
                     "events": [
                         {
                             "name": "Resurrection",
-                            "city": "Viveiro",
+                            "city":  {
+                                "name": "Viveiro",
+                            },
+                            "tickets": "www.example.com/resurrection"
                         }
                     ]
                 }
             ]
         )
+

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,4 @@
 from http import HTTPStatus
-from pprint import pprint
 from unittest.mock import patch
 
 from django.contrib.contenttypes.models import ContentType

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -34,3 +34,7 @@ class TaggedItem(models.Model):
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey('content_type', 'object_id')
+
+
+class Country(models.Model):
+    name = models.CharField(max_length=200)

--- a/tests/testapp/serializers.py
+++ b/tests/testapp/serializers.py
@@ -30,6 +30,14 @@ class EventSerializer(FlexFieldsSerializerMixin, serializers.Serializer):
     city = serializers.CharField()
     tickets = serializers.CharField()
 
+    class Meta:
+        expandable_fields = {
+            "city": serializers.SerializerMethodField
+        }
+    
+    def get_city(self, value):
+        return { "name": value }
+
 
 class CountrySerializer(FlexFieldsModelSerializer):
     events = FlexSerializerMethodField()

--- a/tests/testapp/serializers.py
+++ b/tests/testapp/serializers.py
@@ -35,18 +35,20 @@ class EventSerializer(FlexFieldsSerializerMixin, serializers.Serializer):
             "city": serializers.SerializerMethodField
         }
     
-    def get_city(self, value):
-        return { "name": value }
+    def get_city(self, obj):
+        return { "name": obj["city"] }
 
 
 class CountrySerializer(FlexFieldsModelSerializer):
-    events = FlexSerializerMethodField()
     
     class Meta:
         model = Country
-        fields = ['name', 'events']
+        fields = ['name']
+        expandable_fields = {
+            "events": FlexSerializerMethodField
+        }
 
-    def get_events(self, obj, expand, omit, fields):
+    def get_events(self, obj, fields, expand, omit):
         events = get_event_list(country=obj)
         return EventSerializer(events, many=True, expand=expand, omit=omit, fields=fields).data
 

--- a/tests/testapp/serializers.py
+++ b/tests/testapp/serializers.py
@@ -1,9 +1,10 @@
 from rest_framework import serializers
 from rest_framework.relations import PrimaryKeyRelatedField
 
-from rest_flex_fields import FlexFieldsModelSerializer
-from tests.testapp.models import Pet, PetStore, Person, Company, TaggedItem
-
+from rest_flex_fields.serializers import FlexFieldsModelSerializer, FlexFieldsSerializerMixin
+from rest_flex_fields.fields import FlexSerializerMethodField
+from tests.testapp.models import Pet, PetStore, Person, Company, TaggedItem, Country
+from tests.testapp.utils import get_event_list
 
 class CompanySerializer(FlexFieldsModelSerializer):
     class Meta:
@@ -22,6 +23,23 @@ class PetStoreSerializer(serializers.ModelSerializer):
     class Meta:
         model = PetStore
         fields = ["id", "name"]
+
+
+class EventSerializer(serializers.Serializer, FlexFieldsSerializerMixin):
+    class Meta:
+        fields = ["name", "city", "tickets"]
+
+
+class CountrySerializer(FlexFieldsModelSerializer):
+    events = FlexSerializerMethodField()
+    
+    class Meta:
+        model = Country
+        fields = ['name', 'events']
+
+    def get_events(self, obj, expand, omit, fields):
+        events = get_event_list(country=obj)
+        return EventSerializer(events, many=True, expand=expand, omit=omit, fields=fields).data
 
 
 class PetSerializer(FlexFieldsModelSerializer):
@@ -45,7 +63,11 @@ class PetSerializer(FlexFieldsModelSerializer):
         if obj.name == "Garfield":
             return "homemade lasanga"
         return "pet food"
-
+    
+    def get_info(self, obj, expand, fields, omit):
+        {
+            "is_vegetarian": obj.diet
+        }
 
 class TaggedItemSerializer(FlexFieldsModelSerializer):
     content_object = PrimaryKeyRelatedField(read_only=True)

--- a/tests/testapp/serializers.py
+++ b/tests/testapp/serializers.py
@@ -25,9 +25,10 @@ class PetStoreSerializer(serializers.ModelSerializer):
         fields = ["id", "name"]
 
 
-class EventSerializer(serializers.Serializer, FlexFieldsSerializerMixin):
-    class Meta:
-        fields = ["name", "city", "tickets"]
+class EventSerializer(FlexFieldsSerializerMixin, serializers.Serializer):
+    name = serializers.CharField()
+    city = serializers.CharField()
+    tickets = serializers.CharField()
 
 
 class CountrySerializer(FlexFieldsModelSerializer):

--- a/tests/testapp/utils.py
+++ b/tests/testapp/utils.py
@@ -1,0 +1,25 @@
+EVENTS = {
+    "Germany": [
+        {
+            "name": "Wacken Open Air",
+            "city": "Wacken",
+            "tickets": "www.example.com/wacken"
+        },
+        {
+            "name": "Full Force",
+            "city": "Grafenhainichen",
+            "tickets": "www.example.com/full_force"
+        }
+    ],
+    "Spain": [
+        {
+            "name": "Resurrection",
+            "city": "Viveiro",
+            "tickets": "www.example.com/resurrection"
+        }
+    ]
+}
+
+
+def get_event_list(country):
+    return EVENTS[country.name]

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -1,8 +1,9 @@
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.viewsets import ModelViewSet, GenericViewSet
+from rest_framework.mixins import ListModelMixin
 
 from rest_flex_fields import FlexFieldsModelViewSet
-from tests.testapp.models import Pet, TaggedItem
-from tests.testapp.serializers import PetSerializer, TaggedItemSerializer
+from tests.testapp.models import Pet, TaggedItem, Country
+from tests.testapp.serializers import PetSerializer, TaggedItemSerializer, CountrySerializer
 
 
 class PetViewSet(FlexFieldsModelViewSet):
@@ -18,3 +19,8 @@ class PetViewSet(FlexFieldsModelViewSet):
 class TaggedItemViewSet(ModelViewSet):
     serializer_class = TaggedItemSerializer
     queryset = TaggedItem.objects.all()
+
+
+class CountryEventsViewset(GenericViewSet, ListModelMixin):
+    serializer_class = CountrySerializer
+    queryset = Country.objects.all()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,10 +1,11 @@
 from django.conf.urls import url, include
 from rest_framework import routers
-from tests.testapp.views import PetViewSet, TaggedItemViewSet
+from tests.testapp.views import PetViewSet, TaggedItemViewSet, CountryEventsViewset
 
 # Standard viewsets
 router = routers.DefaultRouter()
 router.register(r"pets", PetViewSet, basename="pet")
 router.register(r"tagged-items", TaggedItemViewSet, basename="tagged-item")
+router.register(r"country_events", CountryEventsViewset, basename="country-events")
 
 urlpatterns = [url(r"^", include(router.urls))]


### PR DESCRIPTION
Attempt at implementation of the `FlexSerializerMethodField` class discussed in #54 with docs and test coverage.

The case I used as a test for both the doc and unittests seems like it could be more simple, but I couldn't think of any simpler serializer structure.