### PR TITLE
Feat: add check to convert from `django.HttpRequest` to `drf.Request`

### DIFF
--- a/rest_flex_fields/serializers.py
+++ b/rest_flex_fields/serializers.py
@@ -2,7 +2,9 @@ import copy
 import importlib
 from typing import List, Optional, Tuple
 
+from django.http.request import HttpRequest
 from rest_framework import serializers
+from rest_framework.request import Request
 
 from rest_flex_fields import (
     EXPAND_PARAM,
@@ -277,6 +279,10 @@ class FlexFieldsSerializerMixin(object):
 
         if not hasattr(self, "context") or not self.context.get("request"):
             return []
+
+        # Convert to drf Request
+        if isinstance(self.context['request'], HttpRequest):
+            self.context["request"] = Request(self.context["request"])
 
         values = self.context["request"].query_params.getlist(field)
 

--- a/rest_flex_fields/serializers.py
+++ b/rest_flex_fields/serializers.py
@@ -280,7 +280,6 @@ class FlexFieldsSerializerMixin(object):
         if not hasattr(self, "context") or not self.context.get("request"):
             return []
 
-        # Convert to drf Request
         if isinstance(self.context['request'], HttpRequest):
             self.context["request"] = Request(self.context["request"])
 

--- a/rest_flex_fields/utils.py
+++ b/rest_flex_fields/utils.py
@@ -1,5 +1,8 @@
 from collections.abc import Iterable
 
+from django.http.request import HttpRequest
+from rest_framework.request import Request
+
 from rest_flex_fields import EXPAND_PARAM, FIELDS_PARAM, OMIT_PARAM, WILDCARD_VALUES
 
 
@@ -7,6 +10,9 @@ def is_expanded(request, field: str) -> bool:
     """ Examines request object to return boolean of whether
         passed field is expanded.
     """
+    if isinstance(request, HttpRequest):
+        request = Request(request)
+
     expand_value = request.query_params.get(EXPAND_PARAM)
     expand_fields = []
 
@@ -23,6 +29,9 @@ def is_included(request, field: str) -> bool:
         set, and it is not among them, or because `omit` is set and
         it is among them.
     """
+    if isinstance(request, HttpRequest):
+        request = Request(request)
+
     sparse_value = request.query_params.get(FIELDS_PARAM)
     omit_value = request.query_params.get(OMIT_PARAM)
     sparse_fields, omit_fields = [], []


### PR DESCRIPTION
Solves the issue mentioned in #128 . This can be a problem when testing with you use the django default `RequestFactory` for example. Since it's a simple fix it seems worth implementing.