### PR TITLE
Handle missing coreapi in DRF 3.17

### DIFF
--- a/rest_flex_fields/filter_backends.py
+++ b/rest_flex_fields/filter_backends.py
@@ -4,7 +4,15 @@ from typing import Optional
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models import QuerySet
-from rest_framework.compat import coreapi, coreschema
+try:
+    from rest_framework.compat import coreapi, coreschema
+except ImportError:
+    try:
+        import coreapi
+        import coreschema
+    except ImportError:
+        coreapi = None
+        coreschema = None
 from rest_framework.filters import BaseFilterBackend
 from rest_framework.request import Request
 from rest_framework.viewsets import GenericViewSet


### PR DESCRIPTION
DRF 3.17 removed `coreapi` and `coreschema` from `rest_framework.compat`, so importing `FlexFieldsFilterBackend` currently fails before `get_schema_fields()` can hit its existing optional dependency assertions.

This keeps compatibility with older DRF versions and falls back to direct optional imports for DRF 3.17+. If neither package is installed, the existing assertions still report that schema generation requires them.

Fixes #145.